### PR TITLE
Document latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ and start its application:
       [applications: [:peerage]]
     end
     def deps do
-      [{:peerage, "~> 0.3.4"}]
+      [{:peerage, "~> 1.0.2"}]
     end
 ```
+
+Note that the latest hex version may be higher than what is listed here. You can
+find the latest version on [hex](https://hex.pm/packages/peerage). You should match
+the version or alternatively you can use a looser version constraint like `"~> 1.0"`.
 
 ## Usage
 


### PR DESCRIPTION
This documents the latest version but also instructions on how to find the latest version on hex.

This hung me up for about 15 minutes as the log_results was always happening on 0.3.4 as well as compilation errors from the older Elixir versioning.