### PR TITLE
Wrap the Logger outputs from DNS strategy in conditional

### DIFF
--- a/lib/peerage/dns.ex
+++ b/lib/peerage/dns.ex
@@ -29,23 +29,42 @@ defmodule Peerage.Via.Dns do
   def poll, do: lookup() |> to_names([])
 
   defp lookup do
-    hostname() |> String.to_charlist |> :inet_res.lookup(:in, :a)
+    hostname() |> String.to_charlist() |> :inet_res.lookup(:in, :a)
   end
 
   # turn list of ips into list of node names
   defp to_names([ip | rest], acc) when is_list(acc) do
-    Logger.debug " -> Peerage.Via.Dns resolved '#{hostname()}' to #{ to_s(ip) } "
-    to_names rest, [:"#{ app_name() }@#{ to_s(ip) }"] ++ acc
+    case log_results?() do
+      true -> Logger.debug(" -> Peerage.Via.Dns resolved '#{hostname()}' to #{to_s(ip)} ")
+      false -> nil
+    end
+
+    to_names(rest, [:"#{app_name()}@#{to_s(ip)}"] ++ acc)
   end
+
   defp to_names([], lst), do: lst
-  defp to_names(err,[]),  do: Logger.error(["dns err",err]); []
+
+  defp to_names(err, []) do
+    case log_results?() do
+      true -> Logger.error(["dns err", err])
+      false -> nil
+    end
+
+    []
+  end
 
   # helpers
   defp app_name do
     Application.get_env(:peerage, :app_name, "nonode")
   end
+
   defp hostname do
     Application.get_env(:peerage, :dns_name, "localhost")
   end
-  defp to_s(_ip = {a,b,c,d}), do: "#{a}.#{b}.#{c}.#{d}"
+
+  defp log_results? do
+    Application.get_env(:peerage, :log_results, true)
+  end
+
+  defp to_s(_ip = {a, b, c, d}), do: "#{a}.#{b}.#{c}.#{d}"
 end

--- a/test/lib/dns_test.exs
+++ b/test/lib/dns_test.exs
@@ -1,0 +1,42 @@
+defmodule Peerage.Via.DnsTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+
+  @app :a1234
+
+  defmodule M do
+    def f, do: "your key is 1234. write it down."
+  end
+
+  def setup do
+    delete_all_env(@app)
+    :ok
+  end
+
+  test "Peerage.Via.Dns.poll logs connection" do
+    Application.put_env(:peerage, :dns_name, "localhost")
+    Application.put_env(:peerage, :app_name, "peerage")
+    # note: if you're not connected to a network this won't work.
+    #  it's dns resolution...
+    fun = &Peerage.Via.Dns.poll/0
+    assert capture_log(fun) =~ "resolved"
+  end
+
+  test "Peerage.Via.Dns.poll doesn't log connection if log_results set to false" do
+    Application.put_env(:peerage, :dns_name, "localhost")
+    Application.put_env(:peerage, :app_name, "peerage")
+    Application.put_env(:peerage, :log_results, false)
+    # note: if you're not connected to a network this won't work.
+    #  it's dns resolution...
+    fun = &Peerage.Via.Dns.poll/0
+    assert capture_log(fun) == ""
+  end
+
+  defp delete_all_env(app) do
+    app
+    |> Application.get_all_env()
+    |> Enum.each(fn {k, _} ->
+      Application.delete_env(app, k)
+    end)
+  end
+end


### PR DESCRIPTION
Using the DNS strategy, I'm still getting debug statements even with the log_results config set to false.

So I've wrapped the DNS logger statements in a conditional, checking the `log_results` config.