### PR TITLE
Add sync_offset option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Optional config for all apps
 config :abc, via: SomeProvider,
   serves: false,     # true if provider runs supervised
   interval: 15,      # default 10
-  log_results: true  # show connection results in debug mode?
+  log_results: true, # show connection results in debug mode?
+  sync_offset: 300   # peerage starts connecting nodes after this interval milliseconds. default 500
 ```
 
 See specific providers for their additional config.


### PR DESCRIPTION
I added the option `sync_offset` in README.md. This option used in `Peerage.Server` module ([here](https://github.com/ishikawa/peerage/blob/master/lib/peerage/server.ex#L24)).

